### PR TITLE
Replace variable names with space in spreadsheet import

### DIFF
--- a/magrit_app/app.py
+++ b/magrit_app/app.py
@@ -1069,7 +1069,10 @@ async def convert_tabular(request):
         name, extension = name.split('.')
         book = get_book(file_content=data.read(), file_type=extension)
         sheet_names = book.sheet_names()
-        result = book[sheet_names[0]].csv
+        csv = book[sheet_names[0]].csv
+        # replace spaces in variable names
+        firstrowlength = csv.find('\n')
+        result = csv[0:firstrowlength].replace(' ','_')+csv[firstrowlength:]
         message = ["app_page.common.warn_multiple_sheets", sheet_names] if len(sheet_names) > 1 else None
     else:
         result = "Unknown tabular file format"


### PR DESCRIPTION
Using Magrit with students, they format data in unexpected way, such as variables names with spaces in spreadsheet (this example causes several bugs when trying to use the data) ; I know it is better to require decent formatting, but we can never expect the user to follow them. (if the modification is not satisfactory, maybe replace by an error raising if a space is found ?)