### PR TITLE
Improve positioning of the waffles in Waffle Maps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Current master (Not released yet)
+---------------------------------
+
+- Improve positioning of the waffles in Waffle Map (so that the center of the waffle block falls on the x-center, instead of the behavior until now where it was the lower right corner).
+
+
 0.9.2 (2022-09-08)
 -----------------
 

--- a/client/js/function.js
+++ b/client/js/function.js
@@ -767,7 +767,7 @@ export function render_twostocks_waffle(layer, rendering_params) {
 
   if (symbol_type === 'circle') {
     const r = rendering_params.size;
-    const offset_centroid_x = ((r * 2) * nCol) / 2 - r;
+    const offset_centroid_x = (2 * r * nCol) / 2 - r;
     for (let j = 0; j < data_manager.result_data[layer_to_add].length; j++) {
       const centroid = path.centroid({
         type: 'Point',
@@ -802,7 +802,7 @@ export function render_twostocks_waffle(layer, rendering_params) {
   } else if (symbol_type === 'rect') {
     const width = rendering_params.size;
     const offset = width / 5;
-    const offset_centroid_x = (width + offset) * (nCol - 1) / 2 - width / 2;
+    const offset_centroid_x = ((width + offset) * (nCol - 1) - width) / 2;
     for (let j = 0; j < data_manager.result_data[layer_to_add].length; j++) {
       const centroid = path.centroid({
         type: 'Point',

--- a/client/js/function.js
+++ b/client/js/function.js
@@ -767,6 +767,7 @@ export function render_twostocks_waffle(layer, rendering_params) {
 
   if (symbol_type === 'circle') {
     const r = rendering_params.size;
+    const offset_centroid_x = ((r * 2) * nCol) / 2 - r;
     for (let j = 0; j < data_manager.result_data[layer_to_add].length; j++) {
       const centroid = path.centroid({
         type: 'Point',
@@ -781,8 +782,8 @@ export function render_twostocks_waffle(layer, rendering_params) {
         group.append('circle')
           .attrs({
             transform: `translate(-${t_x}, -${t_y})`,
-            cx: centroid[0],
-            cy: centroid[1],
+            cx: centroid[0] + offset_centroid_x,
+            cy: centroid[1] - r,
             r: r,
             id: ['waffle_', i, ' feature_', data_manager.result_data[layer_to_add][j].id].join(''),
             fill: _colors[i],
@@ -801,6 +802,7 @@ export function render_twostocks_waffle(layer, rendering_params) {
   } else if (symbol_type === 'rect') {
     const width = rendering_params.size;
     const offset = width / 5;
+    const offset_centroid_x = (width + offset) * (nCol - 1) / 2 - width / 2;
     for (let j = 0; j < data_manager.result_data[layer_to_add].length; j++) {
       const centroid = path.centroid({
         type: 'Point',
@@ -815,8 +817,8 @@ export function render_twostocks_waffle(layer, rendering_params) {
         group.append('rect')
           .attrs({
             transform: `translate(-${t_x}, -${t_y})`,
-            x: centroid[0],
-            y: centroid[1],
+            x: centroid[0] + offset_centroid_x,
+            y: centroid[1] - width,
             width: width,
             height: width,
             id: ['waffle_', i, ' feature_', data_manager.result_data[layer_to_add][j].id].join(''),

--- a/client/js/map_ctrl.js
+++ b/client/js/map_ctrl.js
@@ -164,7 +164,7 @@ export function reproj_symbol_layer() {
       if (data_manager.current_layers[lyr_name].symbol === 'circle') {
         const r = data_manager.current_layers[lyr_name].size;
         const nCol = data_manager.current_layers[lyr_name].nCol;
-        const offset_centroid_x = ((r * 2) * nCol) / 2 - r;
+        const offset_centroid_x = (2 * r * nCol) / 2 - r;
         for (let i = 0; i < nbFt; i++) {
           const centroid = path.centroid({
             type: 'Point',
@@ -180,7 +180,7 @@ export function reproj_symbol_layer() {
         const width = data_manager.current_layers[lyr_name].size;
         const nCol = data_manager.current_layers[lyr_name].nCol;
         const offset = width / 5;
-        const offset_centroid_x = (width + offset) * (nCol - 1) / 2 - width / 2;
+        const offset_centroid_x = ((width + offset) * (nCol - 1) - width) / 2;
         for (let i = 0; i < nbFt; i++) {
           const centroid = path.centroid({
             type: 'Point',

--- a/client/js/map_ctrl.js
+++ b/client/js/map_ctrl.js
@@ -162,6 +162,9 @@ export function reproj_symbol_layer() {
       const selection = svg_map.querySelector(`#${global._app.layer_to_id.get(lyr_name)}`).querySelectorAll('g');
       const nbFt = selection.length;
       if (data_manager.current_layers[lyr_name].symbol === 'circle') {
+        const r = data_manager.current_layers[lyr_name].size;
+        const nCol = data_manager.current_layers[lyr_name].nCol;
+        const offset_centroid_x = ((r * 2) * nCol) / 2 - r;
         for (let i = 0; i < nbFt; i++) {
           const centroid = path.centroid({
             type: 'Point',
@@ -169,11 +172,15 @@ export function reproj_symbol_layer() {
           });
           const symbols = selection[i].querySelectorAll('circle');
           for (let j = 0, nb_symbol = symbols.length; j < nb_symbol; j++) {
-            symbols[j].setAttribute('cx', centroid[0]);
-            symbols[j].setAttribute('cy', centroid[1]);
+            symbols[j].setAttribute('cx', centroid[0] + offset_centroid_x);
+            symbols[j].setAttribute('cy', centroid[1] - r);
           }
         }
-      } else {
+      } else { // so symbol is 'rect'
+        const width = data_manager.current_layers[lyr_name].size;
+        const nCol = data_manager.current_layers[lyr_name].nCol;
+        const offset = width / 5;
+        const offset_centroid_x = (width + offset) * (nCol - 1) / 2 - width / 2;
         for (let i = 0; i < nbFt; i++) {
           const centroid = path.centroid({
             type: 'Point',
@@ -181,8 +188,8 @@ export function reproj_symbol_layer() {
           });
           const symbols = selection[i].querySelectorAll('rect');
           for (let j = 0, nb_symbol = symbols.length; j < nb_symbol; j++) {
-            symbols[j].setAttribute('x', centroid[0]);
-            symbols[j].setAttribute('y', centroid[1]);
+            symbols[j].setAttribute('x', centroid[0] + offset_centroid_x);
+            symbols[j].setAttribute('y', centroid[1] - width);
           }
         }
       }


### PR DESCRIPTION
Improve the positioning of the waffles on the x axis, as discussed a few days ago.
I also slightly changed the position on the y axis so that it is the same for circle and square.
See screenshots below (gold-black dot is the centroid).

@rCarto @rysebaert is it OK for you ? (in particular the new positioning on the y axis - or do you prefer the center of the lowest symbol to be located at the centroid on the y-axis ?)


<details>
  <summary>Waffle - square - before</summary>

![old-square1](https://user-images.githubusercontent.com/12172162/191314771-22564742-5675-4361-a35e-5fd7d23ce00a.png)

</details>


<details>
  <summary>Waffle - circle - before</summary>

![old-circle1](https://user-images.githubusercontent.com/12172162/191314744-fa232f53-cadc-4f0c-97d6-96667ab6b6cc.png)

</details>


<details>
  <summary>Waffle - square - after</summary>

![new-square1](https://user-images.githubusercontent.com/12172162/191314709-7a7d8321-4c86-413e-8234-e74ccfc35c88.png)

</details>


<details>
  <summary>Waffle - circle - after</summary>

![new-circle1](https://user-images.githubusercontent.com/12172162/191314667-1858e541-990f-4888-9804-4a40d4cac293.png)

</details>