### PR TITLE
Fix/Column title in label options not properly aligned

### DIFF
--- a/client/js/layers_style_popup.js
+++ b/client/js/layers_style_popup.js
@@ -2114,7 +2114,7 @@ function make_generate_labels_section(parent_node, layer_name) {
               li.append('div')
                 .styles({
                   width: '200px',
-                  height: '30px',
+                  transform: 'translateY(6%)',
                   'vertical-align': 'middle',
                   'margin-left': '10px',
                   display: 'inline-block',

--- a/client/js/layers_style_popup.js
+++ b/client/js/layers_style_popup.js
@@ -2114,6 +2114,9 @@ function make_generate_labels_section(parent_node, layer_name) {
               li.append('div')
                 .styles({
                   width: '200px',
+                  overflow: 'hidden',
+                  'white-space': 'nowrap',
+                  'text-overflow': 'ellipsis',
                   'vertical-align': 'middle',
                   'margin-left': '10px',
                   display: 'inline-block',

--- a/client/js/layers_style_popup.js
+++ b/client/js/layers_style_popup.js
@@ -2121,6 +2121,7 @@ function make_generate_labels_section(parent_node, layer_name) {
                   'margin-left': '10px',
                   display: 'inline-block',
                 })
+                .attr('title', f_name)
                 .text(f_name);
 
               const inpputPx = li.append('div');

--- a/client/js/layers_style_popup.js
+++ b/client/js/layers_style_popup.js
@@ -2114,7 +2114,6 @@ function make_generate_labels_section(parent_node, layer_name) {
               li.append('div')
                 .styles({
                   width: '200px',
-                  transform: 'translateY(6%)',
                   'vertical-align': 'middle',
                   'margin-left': '10px',
                   display: 'inline-block',


### PR DESCRIPTION
Hello Magrit team,

I noticed a very very minor thing while implementing the new changes introduced since 0.15.0.

The fields titles in the label creation popup are not vertically aligned and can overlap if the column name is too long.
I did a small CSS fix, I'll let you check it out. It's basically not forcing height and let the flexbox do its thing to align the items.

Before : 

<img width="799" alt="Screenshot 2023-05-17 at 14 44 06" src="https://github.com/riatelab/magrit/assets/72390360/ee2dd606-9718-4518-b9ad-7007d3dc7839">


After : 

<img width="702" alt="Screenshot 2023-05-17 at 14 53 22" src="https://github.com/riatelab/magrit/assets/72390360/dcdcede9-dca9-47f5-a4f0-1058ddff870c">



If you don't like it or would like a change, please let me know,

Robin

