### PR TITLE
Feature : scale prop symbols and images using a slider

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1295,3 +1295,28 @@ table.gpkg-list-layers td {
   padding: 5px;
   max-width: 325px;
 }
+
+/* slider */
+
+/* la zone de déplacement */
+input[type=range]#zoom-slider::-moz-range-track {
+  
+  
+  box-shadow: none; /* Remove box shadow */
+  border: 1px solid rgba(146, 146, 146,20);
+  
+  height: 6px;
+  background-color: transparent;
+}
+/* le curseur */
+input[type=range]#zoom-slider::-moz-range-thumb {
+
+  background: rgb(77, 76, 76);
+  border-radius: 30%;
+}
+/* barre progression avant */
+input[type=range]#zoom-slider::-moz-range-progress {
+  
+  background: #595959;        /* supprime barre progression avant */
+  height : 6px
+}

--- a/client/js/interface.js
+++ b/client/js/interface.js
@@ -1188,6 +1188,7 @@ export function handle_click_hand(behavior) {
   // eslint-disable-next-line no-param-reassign
   const b = typeof behavior === 'object' ? (!hb.classed('locked') ? 'lock' : 'unlock') : (behavior && typeof behavior === 'string' ? behavior : false);
   if (b === 'lock') {
+    document.getElementById("scale_panel").style.display = "none"
     hb.classed('locked', true);
     hb.html('<img src="static/img/Twemoji_1f512.png" width="18" height="18" alt="locked"/>');
     map.select('.brush').remove();
@@ -1197,6 +1198,7 @@ export function handle_click_hand(behavior) {
     zoom.on('zoom', (() => { const blocked = svg_map.__zoom; return function () { this.__zoom = blocked; }; })());
   } else {
     hb.classed('locked', false);
+    document.getElementById("scale_panel").style.display = ""
     hb.html('<img src="static/img/Twemoji_1f513.png" width="18" height="18" alt="unlocked"/>');
     zoom.on('zoom', zoom_without_redraw);
     document.getElementById('zoom_in').parentElement.style.display = '';

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -10,6 +10,7 @@ import { xhrequest } from './helpers';
 import { Mround } from './helpers_math';
 import { makeSvgMap } from './map_ctrl';
 import { bindTooltips } from './tooltips';
+import { scale_elements } from './scale';
 
 Promise.config({
   warnings: true,
@@ -222,3 +223,5 @@ global.helper_esc_key_twbs_cb = function helper_esc_key_twbs_cb(_event, callback
     }
   }
 };
+
+scale_elements()

--- a/client/js/scale.js
+++ b/client/js/scale.js
@@ -9,27 +9,84 @@ export function scale_elements() {
             background: "transparent",
             position : "absolute",
             left: "0px",
-            bottom : "5px"
+            bottom : "1px",
+            width: "300px",
         });
 
     
 
-    // Add the slider
-    const sliderContainer = div.append("div").attr("class", "slider_container");
+    // Create scale container
+    const scaleContainer = div.append("div")
+        .attr("class", "scale_container")
+        .styles({
+            "display" : "flex",
+            "flex-direction" : "column",
+            "align-items" : "center",
+            "justify-content" : "center",
+        });
+
+    // actual zoom span
+    scaleContainer.append("span")
+        .attrs({ id: "scale_value" })
+        .text("1")
+        .styles({
+            height:"100%",
+            "line-height": "10px",
+        });
+
+ 
+
+    const sliderContainer = scaleContainer.append("div").attr("class", "slider_container")
+        .styles({
+            "display" : "flex",
+            "align-items" : "center",
+            "justify-content" : "center",
+            "background": "transparent",
+        });
+    // Append scale out button to container
+    const scaleOutButton = sliderContainer.append("button")
+        .text("-")
+        .attrs({ id: "scale_out" })
+        .styles({
+            height:"100%",
+            width:"20px",
+            "background-image":"linear-gradient(rgb(136, 136, 136), rgb(85, 85, 85))",
+            color:"white",
+            border : "0px",
+            "border-radius": "3px"
+        });
     sliderContainer
         .append("input")
         .attr("type", "range")
         .attr("id", "zoom-slider")
-        .attr("min", 0.1)
-        .attr("max", 4)
-        .attr("value", 2)
-        .attr("step", 0.1)
+        .attr("min", 0)
+        .attr("max", 2)
+        .attr("value", 1)
+        .attr("step", 0.05)
         .styles({
-            width : "150px",
+            "padding-left": "6px",
+            "padding-right": "6px",
             
         });
     
-    let button_section = div
+    // Then append scale in button to scale container
+    const scaleInButton = sliderContainer.append("button")
+        .text("+")
+        .attrs({ id: "scale_in" })
+        .styles({
+            height:"100%",
+            width:"20px",
+            "background-image":"linear-gradient(rgb(136, 136, 136), rgb(85, 85, 85))",
+            color:"white",
+            border : "0px",
+            "border-radius": "3px"
+        });
+
+
+
+
+
+    /* let button_section = div
         .append("div")
         .attrs({id:"scale_buttons_section"})
         .styles({
@@ -78,7 +135,7 @@ export function scale_elements() {
              border : "0px",
              "border-radius": "3px"
 
-            });
+            }); */
     
 
     const map = d3.select("#svg_map").nodes()[0].childNodes;

--- a/client/js/scale.js
+++ b/client/js/scale.js
@@ -1,0 +1,327 @@
+export function scale_elements() {
+
+    let div = map_div
+        .insert("div", ":first-child")
+        .attrs({ id: "demo" })
+        .styles({
+            "z-index": "999",
+            width: "min-content",
+            background: "transparent",
+            position : "absolute",
+            left: "0px",
+            bottom : "5px"
+        });
+
+    
+
+    // Add the slider
+    const sliderContainer = div.append("div").attr("class", "slider_container");
+    sliderContainer
+        .append("input")
+        .attr("type", "range")
+        .attr("id", "zoom-slider")
+        .attr("min", 0.1)
+        .attr("max", 4)
+        .attr("value", 2)
+        .attr("step", 0.1)
+        .styles({
+            width : "150px",
+            
+        });
+    
+    let button_section = div
+        .append("div")
+        .attrs({id:"scale_buttons_section"})
+        .styles({
+            "display" : "flex",
+            "gap" : "1vw",
+            "justify-content":"center",
+            "height":"20px"
+            
+        })
+    
+    // scale out button
+    button_section
+        .append("button")
+        .text("-")
+        .attrs({ id: "scale_out" })
+        .styles({
+            height:"100%",
+            width:"20px",
+             "background-image":"linear-gradient(rgb(136, 136, 136), rgb(85, 85, 85))",
+             color:"white",
+             border : "0px",
+             "border-radius": "3px"
+
+            });
+
+    // span showing the slider value
+    button_section
+        .append("span")
+        .attrs({ id: "scale_value" })
+        .text("2")
+        .styles({
+            height:"100%",
+            width:"fit-content",                              
+        });
+
+    // scale in button
+    button_section
+        .append("button")
+        .text("+")
+        .attrs({ id: "scale_in" })
+        .styles({
+             height:"100%",
+             width:"20px",
+             "background-image":"linear-gradient(rgb(136, 136, 136), rgb(85, 85, 85))",
+             color:"white",
+             border : "0px",
+             "border-radius": "3px"
+
+            });
+    
+
+    const map = d3.select("#svg_map").nodes()[0].childNodes;
+
+    const scale_in = document.getElementById("scale_in");
+    const scale_out = document.getElementById("scale_out");
+    const slider = document.getElementById("zoom-slider");
+    const scale_value_span = document.getElementById("scale_value")
+      
+    
+
+    /**
+     * 
+     * We need to figure out a way to know if the user has already used the slider
+     * If they use the button first and not the slider, we need to add the original sizes
+     * from symbols, legends and pictograms in the dom
+     * We only need to add old attributes one time so we dont update it on every user click
+     * 
+     * We use those attributes for the slider scaling because it scales based on the original size
+     * The scaling is asserted from the value of the slider, the chosen step is 0.1.
+     * for exemple: new_size = og_size * 1.2
+     *              new_size = og_size * 1.3
+     * 
+     * 
+     * Also it is important to note that the button adjust the slider 
+     * We do this to preserve a sense cohesion between the scaling of the buttons
+     * and the scaling of the slider
+     */
+    let scaleUsed = false;
+
+    slider.oninput = function () {
+        // scaling is used so the mod will get modified
+        scaleUsed = true;
+        for (let i = 1; i < map.length; i++) {
+            if (
+                !(
+                    map[i].classList.value.split(" ").includes("targeted_layer") ||
+                    map[i].classList.value.split(" ").includes("legend")
+                )
+            ) {
+                for (let children of map[i].children) {
+                    if (children.id.includes("PropSymbol")) {
+                        // Get original size r
+                        let old_r = children.getAttribute("old_r");
+                        // If we only have the original size, we copy it
+                        if (!old_r) {
+                            children.setAttribute("old_r", children.getAttribute("r"));
+                            old_r = children.getAttribute("r");
+                        }
+                        let base_size = parseFloat(old_r);
+
+                        let new_size = base_size * slider.value;
+                        children.setAttribute("r", new_size);
+                    } else if (children.id.includes("Picto")) {
+                        // Same logic as above
+                        let original_height = children.getAttribute("old_height");
+                        let original_width = children.getAttribute("old_width");
+                        if (!original_height && !original_width) {
+                            children.setAttribute(
+                                "old_height",
+                                children.getAttribute("height")
+                            );
+                            children.setAttribute(
+                                "old_width",
+                                children.getAttribute("width")
+                            );
+                            original_height = children.getAttribute("height");
+                            original_width = children.getAttribute("width");
+                        }
+
+                        let height = parseFloat(original_height);
+                        let width = parseFloat(original_width);
+
+                        let update_height = height * slider.value;
+                        let update_width = width * slider.value;
+
+                        children.setAttribute("height", update_height);
+                        children.setAttribute("width", update_width);                       
+                    }
+                }
+
+                let legendes = document.querySelectorAll(
+                    `[class*=${map[i].id}][class*=legend]`
+                );
+                for (let svg_tag of legendes) {
+                    for (let element of svg_tag.childNodes) {
+                        if (element.tagName == "g") {
+                            let original_size = element.firstChild.getAttribute("old_r");
+                            if (!original_size) {
+                                element.firstChild.setAttribute(
+                                    "old_r",
+                                    element.firstChild.getAttribute("r")
+                                );
+                                original_size = element.firstChild.getAttribute("r");
+                            }
+                            let currentTransform = parseFloat(original_size);
+
+                            let updatedTransform =
+                                currentTransform * parseFloat(slider.value);
+                            element.firstChild.setAttribute("r", updatedTransform);
+                        }
+                    }
+                }
+            }
+        }
+    document.getElementById("scale_value").textContent = slider.value
+    };
+
+    /**
+     * Listen onclick events of buttons 
+     * We scale all the shapes of the map and we adjust the slider accordingly
+     */
+    scale_in.onclick = function () {
+        scaleElements("in");
+        adjustSlider("in");
+    };
+
+    scale_out.onclick = function () {
+        scaleElements("out");
+        adjustSlider("out");
+    };
+
+    function scaleElements(scaleType) {
+        if (!scaleUsed) {
+            updateDomAttributes();
+            scaleUsed = true
+        }
+
+        let scale = 1;
+        switch (scaleType) {
+            case "in":
+                scale = 1.1;
+                break;
+
+            case "out":
+                scale = 0.9;
+                break;
+
+            default:
+                scale = 1;
+                break;
+        }
+        for (let i = 1; i < map.length; i++) {
+            if (
+                !(
+                    map[i].classList.value.split(" ").includes("targeted_layer") ||
+                    map[i].classList.value.split(" ").includes("legend")
+                )
+            ) {
+                for (let children of map[i].children) {
+                    if (children.id.includes("PropSymbol")) {
+
+                        let currentTransform = parseFloat(children.getAttribute("r"));
+
+                        let updatedTransform = currentTransform * scale;
+                        children.setAttribute("r", updatedTransform);
+                    } else if (children.id.includes("Picto")) {
+
+                        let height = parseFloat(children.getAttribute("height"));
+                        let width = parseFloat(children.getAttribute("width"));
+
+                        let update_height = height * scale;
+                        let update_width = width * scale;
+
+                        children.setAttribute("height", update_height);
+                        children.setAttribute("width", update_width);
+                    }
+                }
+
+                let legendes = document.querySelectorAll(
+                    `[class*=${map[i].id}][class*=legend]`
+                );
+                for (let svg_tag of legendes) {
+                    for (let element of svg_tag.childNodes) {
+                        if (element.tagName == "g") {
+                            let currentTransform = parseFloat(
+                                element.firstChild.getAttribute("r")
+                            );
+
+                            let updatedTransform = currentTransform * scale;
+                            element.firstChild.setAttribute("r", updatedTransform);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    function adjustSlider(scaleType) {
+        switch (scaleType) {
+            case "in":
+                slider.value =
+                    parseFloat(slider.value) + parseFloat(slider.getAttribute("step"));
+                    scale_value_span.textContent = slider.value
+                break;
+
+            case "out":
+                slider.value =
+                    parseFloat(slider.value) - parseFloat(slider.getAttribute("step"));
+                    scale_value_span.textContent = slider.value
+                break;
+        }
+    }
+
+    function updateDomAttributes() {
+        for (let i = 1; i < map.length; i++) {
+            if (
+                !(
+                    map[i].classList.value.split(" ").includes("targeted_layer") ||
+                    map[i].classList.value.split(" ").includes("legend")
+                )
+            ) {
+                for (let children of map[i].children) {
+                    if (children.id.includes("PropSymbol")) {
+                        // Get original r (size)
+                        children.setAttribute("old_r", children.getAttribute("r"));
+
+                    } else if (children.id.includes("Picto")) {
+                        children.setAttribute(
+                            "old_height",
+                            children.getAttribute("height")
+                        );
+                        children.setAttribute(
+                            "old_width",
+                            children.getAttribute("width")
+                        );
+                    }
+                }
+
+                let legendes = document.querySelectorAll(
+                    `[class*=${map[i].id}][class*=legend]`
+                );
+                for (let svg_tag of legendes) {
+                    for (let element of svg_tag.childNodes) {
+                        if (element.tagName == "g") {
+                            element.firstChild.setAttribute(
+                                "old_r",
+                                element.firstChild.getAttribute("r")
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/client/js/scale.js
+++ b/client/js/scale.js
@@ -2,7 +2,7 @@ export function scale_elements() {
 
     let div = map_div
         .insert("div", ":first-child")
-        .attrs({ id: "demo" })
+        .attrs({ id: "scale_panel" })
         .styles({
             "z-index": "999",
             width: "min-content",

--- a/client/js/scale.js
+++ b/client/js/scale.js
@@ -184,7 +184,7 @@ export function scale_elements() {
                 }
             }
         }
-    document.getElementById("scale_value").textContent = slider.value
+    scale_value_span.textContent = slider.value
     };
 
     /**

--- a/client/js/scale.js
+++ b/client/js/scale.js
@@ -82,62 +82,6 @@ export function scale_elements() {
             "border-radius": "3px"
         });
 
-
-
-
-
-    /* let button_section = div
-        .append("div")
-        .attrs({id:"scale_buttons_section"})
-        .styles({
-            "display" : "flex",
-            "gap" : "1vw",
-            "justify-content":"center",
-            "height":"20px"
-            
-        })
-    
-    // scale out button
-    button_section
-        .append("button")
-        .text("-")
-        .attrs({ id: "scale_out" })
-        .styles({
-            height:"100%",
-            width:"20px",
-             "background-image":"linear-gradient(rgb(136, 136, 136), rgb(85, 85, 85))",
-             color:"white",
-             border : "0px",
-             "border-radius": "3px"
-
-            });
-
-    // span showing the slider value
-    button_section
-        .append("span")
-        .attrs({ id: "scale_value" })
-        .text("2")
-        .styles({
-            height:"100%",
-            width:"fit-content",                              
-        });
-
-    // scale in button
-    button_section
-        .append("button")
-        .text("+")
-        .attrs({ id: "scale_in" })
-        .styles({
-             height:"100%",
-             width:"20px",
-             "background-image":"linear-gradient(rgb(136, 136, 136), rgb(85, 85, 85))",
-             color:"white",
-             border : "0px",
-             "border-radius": "3px"
-
-            }); */
-    
-
     const map = d3.select("#svg_map").nodes()[0].childNodes;
 
     const scale_in = document.getElementById("scale_in");


### PR DESCRIPTION
Hello,

Here is a new features made together with @robLittiere and @DevGuez which implements a slider allowing to rescale proportionnal symbols and images sizes from the map canvas.

![image](https://github.com/riatelab/magrit/assets/84096571/3f7591e8-2f85-4730-9f07-035ee885abc2)


We set the slider and buttons to be visible when the lock is unlocked, with the scale value being displayed in the center, ranging from 0 to 2 with a 0.05 step. It also rescales the legend to match the symbols size.

However, when the page is refreshed, the slider goes back to it's default value (1) and so do the symbols and images, therefore not taking into account the scaling the user could have done as we're not sure how to implement this.
